### PR TITLE
macOS Sierra /usr/bin/security appends a junk line on the entitlement…

### DIFF
--- a/iReSign/iReSign/iReSignAppDelegate.m
+++ b/iReSign/iReSign/iReSignAppDelegate.m
@@ -411,6 +411,16 @@ static NSString *kiTunesMetadataFileName            = @"iTunesMetadata";
 
 - (void)doEntitlementsEdit
 {
+    //macOS 10.12 bug: /usr/bin/security appends a junk line at the top of the XML file.
+    if ([entitlementsResult containsString:@"SecPolicySetValue"])
+    {
+        NSRange newlineRange = [entitlementsResult rangeOfString:@"\n"];
+        if(newlineRange.location != NSNotFound) {
+            entitlementsResult = [entitlementsResult substringFromIndex:newlineRange.location];
+        }
+    }
+    //end macOS 10.12 bug fix.
+    
     NSDictionary* entitlements = entitlementsResult.propertyList;
     entitlements = entitlements[@"Entitlements"];
     NSString* filePath = [workingPath stringByAppendingPathComponent:@"entitlements.plist"];


### PR DESCRIPTION
…s xml/plist file that breaks signing.